### PR TITLE
Add initial docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3
+
+# Drop log meesages directly back to the console
+ENV PYTHONBUFFERED 1
+
+RUN mkdir /app
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt /app/
+RUN pip install -r requirements.txt
+
+# Copy source files
+COPY src/ /app/
+
+# Run entrypoint script for initial setup
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/SETUP.md
+++ b/SETUP.md
@@ -2,6 +2,8 @@
 
 ## Setting up your development environment
 
+_Note_: If you're using `docker-compose`, you can skip to [this section](#docker-compose-setup).
+
 ### Python virtual environment (virtualenv)
 
 For this project, we want to keep all packages separate from your personal
@@ -169,3 +171,35 @@ Start Django
     python manage.py runserver 0.0.0.0:8000
 
 Access the application from the URL http://localhost:8000
+
+### Docker Compose Setup
+
+#### Install docker-compose
+
+[Here](https://docs.docker.com/compose/install/) is a helpful link for installing `docker-compose`.
+
+#### Build and run
+
+Once you have docker-compose installed and running, you can build and run your development environment!
+
+```
+# If you want to follow the server output
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+
+# If you want to run the containers in the background
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+```
+
+For this project, we layer the .yml files to make tweaks between development and production.
+
+#### Access application
+
+Once everything is up and running, you should be able to navigate to http://127.0.0.1:8000 to see the application!
+
+#### Shutdown containers
+
+To shutdown the project whenver you don't want them running, you can use:
+
+```
+docker-compose down
+```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  web:
+    build: .
+    restart: always
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - ./src:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    environment:
+      - STEM_SECRET_KEY=${STEM_SECRET_KEY}
+      - STEM_PSQL_PASSWORD=${STEM_PSQL_PASSWORD}
+      - DOCKER_SETUP_FLAG=TRUE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,20 +3,8 @@ version: '3'
 services:
   db:
     image: postgres
+    restart: always
     environment:
       - POSTGRES_DB=stem_ecosystem
       - POSTGRES_USER=stem_admin
       - POSTGRES_PASSWORD=${STEM_PSQL_PASSWORD}
-  web:
-    build: .
-    command: python manage.py runserver 0.0.0.0:8000
-    volumes:
-      - ./src:/app
-    ports:
-      - "8000:8000"
-    depends_on:
-      - db
-    environment:
-      - STEM_SECRET_KEY=${STEM_SECRET_KEY}
-      - STEM_PSQL_PASSWORD=${STEM_PSQL_PASSWORD}
-      - DOCKER_SETUP_FLAG=TRUE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_DB=stem_ecosystem
+      - POSTGRES_USER=stem_admin
+      - POSTGRES_PASSWORD=${STEM_PSQL_PASSWORD}
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - ./src:/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    environment:
+      - STEM_SECRET_KEY=${STEM_SECRET_KEY}
+      - STEM_PSQL_PASSWORD=${STEM_PSQL_PASSWORD}
+      - DOCKER_SETUP_FLAG=TRUE

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Setup database schema
+python manage.py makemigrations
+python manage.py migrate
+exec "$@"

--- a/src/stem/settings.py
+++ b/src/stem/settings.py
@@ -27,6 +27,12 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
+# Check to see if this was setup with Docker. If not, we'll want to use 
+# localhost address for the database host
+if 'DOCKER_SETUP_FLAG' in os.environ:
+    db_host = 'db'
+else:
+    db_host = '127.0.0.1'
 
 # Application definition
 
@@ -84,7 +90,7 @@ DATABASES = {
         'NAME': 'stem_ecosystem',
         'USER': 'stem_admin',
         'PASSWORD': os.environ['STEM_PSQL_PASSWORD'],
-        'HOST': '127.0.0.1',
+        'HOST': db_host,
         'PORT': '5432',
     }
 }


### PR DESCRIPTION
We talked about using `docker-compose` for easy setup of environments. The more I thought about it, the more I liked the idea of using it for deployment and moving things around. I just wanted to be respectful of those that don't want to/can't use it for development purposes (like myself).

**Important Note**: This does **NOT** impact local development! The piece in `settings.py` checks if Docker was used and adjusts the database host so you're free to use either one! Fun fact: that file is used at runtime so you can freely switch between them without changing settings.