### PR TITLE
Fix docker on Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,3 @@ RUN pip install -r requirements.txt
 
 # Copy source files
 COPY src/ /app/
-
-# Run entrypoint script for initial setup
-COPY docker-entrypoint.sh /usr/local/bin/
-RUN chmod 755 /usr/local/bin/docker-entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/SETUP.md
+++ b/SETUP.md
@@ -230,6 +230,17 @@ For this project, we layer the .yml files to make tweaks between development and
 
 Once everything is up and running, you should be able to navigate to http://127.0.0.1:8000 to see the application!
 
+##### Windows-specific issues
+
+With Windows systems, you'll be running the containers in a virtual machine. So we'll need to get the IP address of that machine. I use [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) so I can use VirtualBox instead of Hyper-V. Therefore, I use the following to get the IP address:
+
+```
+# "box" is my Docker virtual machine name, yours may be different
+docker-machine env box
+```
+
+In the output of that command should include `DOCKER_HOST` which contains an IP address. Put that address in your browser and it should pull up the app (http://<DOCKER_HOST_ADDRESS>:8000)!
+
 #### Shutdown containers
 
 To shutdown the project whenver you don't want them running, you can use:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   web:
     build: .
     restart: always
-    command: bash -c "python manage.py runserver 0.0.0.0:8000"
+    command: bash -c "python manage.py makemigrations && python manage.py migrate && python manage.py loaddata initial_data && python manage.py runserver 0.0.0.0:8000"
     volumes:
       - ./src:/app
     ports:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Setup database schema
-python manage.py makemigrations
-python manage.py migrate
-python manage.py loaddata initial_data
-exec "$@"

--- a/src/stem/settings.py
+++ b/src/stem/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = os.environ['STEM_SECRET_KEY']
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 # Check to see if this was setup with Docker. If not, we'll want to use 
 # localhost address for the database host


### PR DESCRIPTION
Windows is stupid and adds end-of-line characters to all files it pulls from this project. Generally this is fine but shell scripts get hairy. Instead of creating a converting function, we'll push all of the setup steps into `docker-compose.yml`.

This PR also fixes Docker IP issues. Since Docker doesn't run natively on Windows, we need to use the IP address of the VM to actually get the application to load.