### PR TITLE
Add mock data

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -230,6 +230,15 @@ For this project, we layer the .yml files to make tweaks between development and
 
 Once everything is up and running, you should be able to navigate to http://127.0.0.1:8000 to see the application!
 
+##### Default superadmin
+
+The default superadmin account uses the following credentials:
+
+```
+Username: root
+Password: stemecosystem
+```
+
 ##### Windows-specific issues
 
 With Windows systems, you'll be running the containers in a virtual machine. So we'll need to get the IP address of that machine. I use [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/) so I can use VirtualBox instead of Hyper-V. Therefore, I use the following to get the IP address:

--- a/src/app/serializers/user_serializer.py
+++ b/src/app/serializers/user_serializer.py
@@ -10,6 +10,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
             "first_name",
             "last_name",
             "date_of_birth",
+            "organization",
             "user_type",
             "url",
         )

--- a/src/frontend/src/app/models/event.ts
+++ b/src/frontend/src/app/models/event.ts
@@ -2,6 +2,7 @@ export class Event {
 
   name: string;
   date: string;
-  event_type: string;
-  organizer: string;
+  e_type: string;
+  organizer: number;
+  attendees: number[];
 }

--- a/src/frontend/src/app/models/mock-events.ts
+++ b/src/frontend/src/app/models/mock-events.ts
@@ -1,15 +1,10 @@
 import { Event } from '../models/event';
 
 export const EVENTS: Event[] = [
-  { name: 'Camp 1', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Program 2', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Activity 3', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Activity 4', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Activity 5', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Activity 6', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Activity 7', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Activity 8', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Activity 9', date: '08/21/2019', event_type: 'K12/Retreat/Field Trip', organizer: 'Name and/or phone number' },
-  { name: 'Activity 10', date: '08/21/2019', event_type : 'K12/Retreat/Field Trip', organizer : 'Name and/or phone number' }
+  { name: 'Office Party', date: '2019-07-11', e_type: 'Community', organizer: 2, attendees: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] },
+  { name: 'Fundraiser', date: '2019-05-30', e_type: 'Community', organizer: 9, attendees: [3, 6, 7, 8, 13, 16] },
+  { name: 'Fun Run', date: '2019-07-25', e_type: 'Community', organizer: 2, attendees: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] },
+  { name: 'Paper Airplane Design', date: '2019-08-30', e_type: 'Camp', organizer: 5, attendees: [2, 3, 4, 6, 7, 8, 10, 13, 16] },
+  { name: 'Pam\'s Painting', date: '2019-12-11', e_type: 'Camp', organizer: 3, attendees: [2, 6, 7, 13] },
+  { name: 'Pretzel Day', date: '2019-09-10', e_type: 'Camp', organizer: 10, attendees: [2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 15, 16] },
 ];
-

--- a/src/frontend/src/app/models/mock-organizations.ts
+++ b/src/frontend/src/app/models/mock-organizations.ts
@@ -1,0 +1,6 @@
+import { Organization } from '../models/organization';
+
+export const ORGANIZATIONS: Organization[] = [
+    { name: 'Dunder Mifflin', is_approved: true },
+    { name: 'Staples', is_approved: false }
+];

--- a/src/frontend/src/app/models/mock-users.ts
+++ b/src/frontend/src/app/models/mock-users.ts
@@ -1,0 +1,20 @@
+import { User } from '../models/user';
+
+export const USERS: User[] = [
+    { username: 'root', email: 'stem-ecosystem-root@unomaha.edu', first_name: 'Stem', last_name: 'Ecosystem', date_of_birth: '1990-01-01', organization: null, user_type: 4, is_student: false },
+    { username: 'michaelscott', email: 'michael.scott@dunder-mifflin.com', first_name: 'Michael', last_name: 'Scott', date_of_birth: '1964-03-15', organization: 1, user_type: 3, is_student: false },
+    { username: 'pambeesly', email: 'pam.beesly@dunder-mifflin.com', first_name: 'Pam', last_name: 'Beesly', date_of_birth: '1979-03-25', organization: null, user_type: 1, is_student: true },
+    { username: 'tobyflenderson', email: 'toby.flenderson@dunder-mifflin.com', first_name: 'Toby', last_name: 'Flenderson', date_of_birth: '1971-11-14', organization: null, user_type: 3, is_student: false },
+    { username: 'dwightschrute', email: 'dwight.schrute@dunder-mifflin.com', first_name: 'Dwight', last_name: 'Schrute', date_of_birth: '1972-01-20', organization: 2, user_type: 4, is_student: false },
+    { username: 'jimhalpert', email: 'jim.halpert@dunder-mifflin.com', first_name: 'Jim', last_name: 'Halpert', date_of_birth: '1978-10-01', organization: null, user_type: 2, is_student: false },
+    { username: 'andybernard', email: 'andy.bernard@dunder-mifflin.com', first_name: 'Andy', last_name: 'Bernard', date_of_birth: '1973-08-12', organization: null, user_type: 1, is_student: true },
+    { username: 'kevinmalone', email: 'kevin.malone@dunder-mifflin.com', first_name: 'Kevin', last_name: 'Malone', date_of_birth: '1968-06-01', organization: null, user_type: 1, is_student: true },
+    { username: 'angelamartin', email: 'angela.martin@dunder-mifflin.com', first_name: 'Angela', last_name: 'Martin', date_of_birth: '1970-04-22', organization: null, user_type: 3, is_student: false },
+    { username: 'stanleyhudson', email: 'stanley.hudson@dunder-mifflin.com', first_name: 'Stanley', last_name: 'Hudson', date_of_birth: '1960-08-17', organization: null, user_type: 2, is_student: false },
+    { username: 'creedbratton', email: 'creed.bratton@dunder-mifflin.com', first_name: 'Creed', last_name: 'Bratton', date_of_birth: '1943-02-08', organization: null, user_type: 2, is_student: false },
+    { username: 'ryanhoward', email: 'ryan.howard@dunder-mifflin.com', first_name: 'Ryan', last_name: 'Howard', date_of_birth: '1979-05-05', organization: null, user_type: 3, is_student: false },
+    { username: 'kellykapoor', email: 'kelly.kapoor@dunder-mifflin.com', first_name: 'Kelly', last_name: 'Kapoor', date_of_birth: '1980-02-05', organization: null, user_type: 1, is_student: true },
+    { username: 'meredithpalmer', email: 'meredith.palmer@dunder-mifflin.com', first_name: 'Meredith', last_name: 'Palmer', date_of_birth: '1959-05-12', organization: null, user_type: 2, is_student: false },
+    { username: 'darrylphilbin', email: 'darryl.philbin@dunder-mifflin.com', first_name: 'Darryl', last_name: 'Philbin', date_of_birth: '1979-10-02', organization: null, user_type: 1, is_student: true },
+    { username: 'phyllisvance', email: 'phyllis.vance@dunder-mifflin.com', first_name: 'Phyllis', last_name: 'Vance', date_of_birth: '1972-08-23', organization: null, user_type: 3, is_student: false }
+];

--- a/src/frontend/src/app/models/organization.spec.ts
+++ b/src/frontend/src/app/models/organization.spec.ts
@@ -1,0 +1,7 @@
+import { Organization } from './organization';
+
+describe('Organization', () => {
+  it('should create an instance', () => {
+    expect(new Organization()).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/models/organization.ts
+++ b/src/frontend/src/app/models/organization.ts
@@ -1,0 +1,4 @@
+export class Organization {
+    name: string;
+    is_approved: boolean;
+}

--- a/src/frontend/src/app/models/user.spec.ts
+++ b/src/frontend/src/app/models/user.spec.ts
@@ -1,0 +1,7 @@
+import { User } from './user';
+
+describe('User', () => {
+  it('should create an instance', () => {
+    expect(new User()).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/models/user.ts
+++ b/src/frontend/src/app/models/user.ts
@@ -1,0 +1,12 @@
+import { EmailValidator } from '@angular/forms';
+
+export class User {
+    username: string;
+    email: string;
+    first_name: string;
+    last_name: string;
+    date_of_birth: string;
+    organization: number;
+    user_type: number;
+    is_student: boolean;
+}

--- a/src/frontend/src/app/services/organization.service.spec.ts
+++ b/src/frontend/src/app/services/organization.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { OrganizationService } from './organization.service';
+
+describe('OrganizationService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: OrganizationService = TestBed.get(OrganizationService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/services/organization.service.ts
+++ b/src/frontend/src/app/services/organization.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Organization } from '../models/organization';
+import { ORGANIZATIONS } from '../models/mock-organizations';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrganizationService {
+
+  constructor() { }
+
+  getOrganizations(): Organization[] {
+    return ORGANIZATIONS;
+  }
+}

--- a/src/frontend/src/app/services/user.service.spec.ts
+++ b/src/frontend/src/app/services/user.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: UserService = TestBed.get(UserService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/frontend/src/app/services/user.service.ts
+++ b/src/frontend/src/app/services/user.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { User } from '../models/user';
+import { USERS } from '../models/mock-users';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserService {
+
+  constructor() { }
+
+  getUsers(): User[] {
+    return USERS;
+  }
+}


### PR DESCRIPTION
This PR closes #83 as it updates the events mock data to reflect our current backend. It also adds mock data for users and organizations.

Along the way, I remembered we're missing the default `root` login credentials so I added those to the setup doc.