### PR TITLE
Allow frontend to send HTTP requests to the backend

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,5 @@
 Django==2.1.7
+django-cors-headers==2.5.2
 django-filter==2.1.0
 djangorestframework==3.9.1
 Markdown==3.0.1

--- a/src/stem/settings.py
+++ b/src/stem/settings.py
@@ -46,12 +46,14 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'corsheaders',
     'app',
 ]
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',	
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
 	'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -158,3 +160,8 @@ JWT_AUTH = {
 	'JWT_AUTH_COOKIE': None,
     'JWT_RESPONSE_PAYLOAD_HANDLER': 'app.controllers.user_controller.jwt_response_payload_handler',
 }
+
+CORS_ORIGIN_WHITELIST = (
+    'localhost:4200',
+    '127.0.0.1:4200'
+)


### PR DESCRIPTION
With the Docker setup, it can be a real treat to test these pull requests as you have to hit the Angular app to test the frontend but CORS policies will prevent all traffic to the backend. This removes those issues by whitelisting local port 4200 so the frontend can talk to the backend without any issues.