### PR TITLE
Remove code copy of Docker images for faster builds

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -9,6 +9,3 @@ WORKDIR /app
 # Install dependencies
 COPY requirements.txt /app/
 RUN pip install -r requirements.txt
-
-# Copy app code for caching benefits
-COPY . /app/

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -14,6 +14,3 @@ RUN npm -g config set user root
 RUN npm install -g @angular/cli@7.3.1
 RUN npm install -g node-sass
 RUN npm install
-
-# Copy app code for caching benefits
-COPY . /app/


### PR DESCRIPTION
After building a couple PRs, I got to testing the code copy command in our Dockerfiles. In the docs I read, there are some caching benefits to doing this but I don't think it applies for us since we mount our local file system during development anyways. Pulling that thing out appears to not have any negative affects and builds are SO much faster.