### PR TITLE
Send required tags and interests fields with their forms

### DIFF
--- a/src/frontend/src/app/components/register/register.component.html
+++ b/src/frontend/src/app/components/register/register.component.html
@@ -53,8 +53,8 @@
           </mat-form-field>
           <mat-form-field fxFlex="18" fxFlex.lt-sm="90">
             <input matInput placeholder="State" [matAutocomplete]="auto" formControlName="state" />
-            <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
-              <mat-option *ngFor="let state of filteredStates | async" [value]="state.name">
+            <mat-autocomplete autoActiveFirstOption [panelWidth]="150" #auto="matAutocomplete">
+              <mat-option *ngFor="let state of filteredStates | async" [value]="state.abbreviation">
                 {{state.name}}
               </mat-option>
             </mat-autocomplete>

--- a/src/frontend/src/app/components/register/register.component.ts
+++ b/src/frontend/src/app/components/register/register.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MatDialog, MatSnackBar, MatSnackBarVerticalPosition, MatSnackBarHorizontalPosition } from '@angular/material';
+import { MatDialog, MatSnackBar, MatSnackBarVerticalPosition, MatSnackBarHorizontalPosition, MatAutocompleteTrigger } from '@angular/material';
 import { RegistertermsComponent } from './registerterms/registerterms.component';
 import { AuthenticationService } from '../../services/authentication.service';
 import { first } from 'rxjs/operators';
@@ -25,6 +25,8 @@ export class RegisterComponent implements OnInit {
   rightPosition: MatSnackBarHorizontalPosition = 'right';
   error = '';
 
+  @ViewChild(MatAutocompleteTrigger) trigger: MatAutocompleteTrigger;
+
   constructor(
     private router: Router,
     private fb: FormBuilder,
@@ -46,7 +48,7 @@ export class RegisterComponent implements OnInit {
       addressGroup: this.fb.group({
         address: [''],
         city: [''],
-        state: [''],
+        state: ['', [Validators.maxLength(2)]],
         zip: ['', [Validators.pattern(this.zipPattern)]],
       }),
       loginGroup: this.fb.group(
@@ -66,6 +68,7 @@ export class RegisterComponent implements OnInit {
         startWith(''),
         map(value => this._filter(value))
     );
+
   }
 
   // Validate the password and confirm password fields
@@ -151,6 +154,6 @@ export class RegisterComponent implements OnInit {
   private _filter(value: string): State[] {
     const filterValue = value.toLowerCase();
 
-    return this.states.filter(state => state.name.toLowerCase().includes(filterValue));
+    return this.states.filter(state => state.name.toLowerCase().startsWith(filterValue));
   }
 }

--- a/src/frontend/src/app/models/RegisterUser.ts
+++ b/src/frontend/src/app/models/RegisterUser.ts
@@ -11,4 +11,5 @@ export class RegisterUser {
   zip_code: string;
   phone: string;
   parent_id?: string;
+  interests: string[];
 }

--- a/src/frontend/src/app/models/states.ts
+++ b/src/frontend/src/app/models/states.ts
@@ -13,10 +13,6 @@ export const STATES: State[] = [
         "abbreviation": "AK"
     },
     {
-        "name": "American Samoa",
-        "abbreviation": "AS"
-    },
-    {
         "name": "Arizona",
         "abbreviation": "AZ"
     },
@@ -45,20 +41,12 @@ export const STATES: State[] = [
         "abbreviation": "DC"
     },
     {
-        "name": "Federated States Of Micronesia",
-        "abbreviation": "FM"
-    },
-    {
         "name": "Florida",
         "abbreviation": "FL"
     },
     {
         "name": "Georgia",
         "abbreviation": "GA"
-    },
-    {
-        "name": "Guam Gu",
-        "abbreviation": "GU"
     },
     {
         "name": "Hawaii",
@@ -95,10 +83,6 @@ export const STATES: State[] = [
     {
         "name": "Maine",
         "abbreviation": "ME"
-    },
-    {
-        "name": "Marshall Islands",
-        "abbreviation": "MH"
     },
     {
         "name": "Maryland",
@@ -161,10 +145,6 @@ export const STATES: State[] = [
         "abbreviation": "ND"
     },
     {
-        "name": "Northern Mariana Islands",
-        "abbreviation": "MP"
-    },
-    {
         "name": "Ohio",
         "abbreviation": "OH"
     },
@@ -175,10 +155,6 @@ export const STATES: State[] = [
     {
         "name": "Oregon",
         "abbreviation": "OR"
-    },
-    {
-        "name": "Palau",
-        "abbreviation": "PW"
     },
     {
         "name": "Pennsylvania",
@@ -215,10 +191,6 @@ export const STATES: State[] = [
     {
         "name": "Vermont",
         "abbreviation": "VT"
-    },
-    {
-        "name": "Virgin Islands",
-        "abbreviation": "VI"
     },
     {
         "name": "Virginia",

--- a/src/frontend/src/app/services/authentication.service.ts
+++ b/src/frontend/src/app/services/authentication.service.ts
@@ -66,6 +66,7 @@ export class AuthenticationService {
           registerUser.state = stateRes;
           registerUser.zip_code = zipCode;
           registerUser.phone = phoneNumber;
+          registerUser.interests = [];
 
           console.log(registerUser);
 

--- a/src/frontend/src/app/services/event-service.service.ts
+++ b/src/frontend/src/app/services/event-service.service.ts
@@ -31,7 +31,8 @@ export class EventService {
     const obj = {
       name: eventName,
       date: eventDate.toLocaleDateString('en-US'),
-      event_type: eventType
+      event_type: eventType,
+      tags: []
     };
 
     var user = JSON.parse(localStorage.currentUser);


### PR DESCRIPTION
We figured out that I derped again and broke user registration and event creation. This sends those fields as blank to the API so they can easily be added to the frontend later.

This closes #160 