### PR TITLE
Allow Docker to use package-lock during build process

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -8,6 +8,9 @@ ENV PATH=$PATH:/home/node/.npm-global/bin
 
 COPY package.json /app/frontend/
 
+RUN if [ -d /app/frontend/node_modules ]; then rm -rf /app/frontend/node_modules; fi
+RUN if [ -f /app/frontend/package-lock.json ]; then rm /app/frontend/package-lock.json; fi
+
 # Install dependencies
 ## Globally install angular/cli and node-sass
 RUN npm -g config set user root


### PR DESCRIPTION
This PR _should_ fix a bug with `npm install` not following dependency installs.

It's tricky to troubleshoot so I'd like to have @maddagada test this before merging!

If everything works, this will close #159 