### PR TITLE
Add basic input validation to backend

### DIFF
--- a/src/app/controllers/organization_controller.py
+++ b/src/app/controllers/organization_controller.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticated
 
 from app.models.organization import Organization
 from app.serializers.organization_serializer import OrganizationSerializer
@@ -7,3 +8,4 @@ from app.serializers.organization_serializer import OrganizationSerializer
 class OrganizationViewSet(viewsets.ModelViewSet):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
+    permission_classes = [IsAuthenticated,]

--- a/src/app/serializers/event_serializer.py
+++ b/src/app/serializers/event_serializer.py
@@ -1,6 +1,7 @@
 from app.models.user import User
 from app.models.event import Event
 from rest_framework import serializers
+import bleach
 
 class EventSerializer(serializers.HyperlinkedModelSerializer):
     organizer = serializers.HyperlinkedRelatedField(view_name='user-detail', queryset=User.objects.all(), default=serializers.CurrentUserDefault())
@@ -22,3 +23,6 @@ class EventSerializer(serializers.HyperlinkedModelSerializer):
     def get_validation_exclusions(self):
         exclusions = super(EventSerializer, self).get_validation_exclusions()
         return exclusions + ['organizer']
+
+    def validate_name(self, value):
+        return bleach.clean(value)

--- a/src/app/serializers/organization_serializer.py
+++ b/src/app/serializers/organization_serializer.py
@@ -1,7 +1,10 @@
 from app.models.organization import Organization
 from rest_framework import serializers
+import bleach
 
 class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
+    is_approved = serializers.BooleanField(read_only=True, default=False)
+
     class Meta:
         model = Organization
         fields = (
@@ -9,3 +12,6 @@ class OrganizationSerializer(serializers.HyperlinkedModelSerializer):
             "is_approved",
             "url"
         )
+
+    def validate_name(self, value):
+        return bleach.clean(value)

--- a/src/app/serializers/user_serializer.py
+++ b/src/app/serializers/user_serializer.py
@@ -1,5 +1,6 @@
 from app.models.user import User
 from rest_framework import serializers
+import bleach
 
 class ChildrenListingField(serializers.RelatedField):
     def to_representation(self, value):
@@ -39,3 +40,21 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         user.set_password(validated_data['password'])
         user.save()
         return user
+
+    def validate_username(self, value):
+        return bleach.clean(value)
+
+    def validate_email(self, value):
+        return bleach.clean(value)
+
+    def validate_first_name(self, value):
+        return bleach.clean(value)
+
+    def validate_last_name(self, value):
+        return bleach.clean(value)
+
+    def validate_address(self, value):
+        return bleach.clean(value)
+
+    def validate_city(self, value):
+        return bleach.clean(value)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,10 +1,14 @@
+bleach==3.1.0
 Django==2.1.7
 django-cors-headers==2.5.2
 django-filter==2.1.0
+django-spa==0.2.0
 djangorestframework==3.9.1
+djangorestframework-jwt==1.11.0
 Markdown==3.0.1
 psycopg2-binary==2.7.7
+PyJWT==1.7.1
 pytz==2018.9
+six==1.12.0
+webencodings==0.5.1
 whitenoise==3.2.2
-django-spa==0.2.0
-djangorestframework-jwt==1.11.0


### PR DESCRIPTION
This closes #137 as it adds basic input validation to the REST API side of the application. I only included the necessary fields to meet base requirements but we can certainly expand them if need be!