### PR TITLE
Deploy to prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # Node static files
 /src/static
+/prod/nginx/stem-portal

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,63 @@
+version: '3'
+
+services:
+  db:
+    image: postgres
+    restart: always
+    environment:
+      - POSTGRES_DB=stem_ecosystem
+      - POSTGRES_USER=stem_admin
+      - POSTGRES_PASSWORD=${STEM_PSQL_PASSWORD}
+    volumes:
+      - postgres-config:/etc/postgresql
+      - postgres-data:/var/lib/postgresql/data
+      - postgres-logs:/var/log/postgresql
+
+  django:
+    build: 
+      context: ./src
+      dockerfile: ./Dockerfile
+    restart: always
+    working_dir: /app
+    command: bash -c "python manage.py makemigrations && python manage.py migrate && python manage.py collectstatic --no-input && gunicorn stem.wsgi:application --bind 0.0.0.0:8000"
+    volumes:
+      - ./src:/app
+      - django-static:/app/static
+    expose:
+      - 8000
+    depends_on:
+      - db
+    environment:
+      - STEM_SECRET_KEY=${STEM_SECRET_KEY}
+      - STEM_PSQL_PASSWORD=${STEM_PSQL_PASSWORD}
+      - DOCKER_SETUP_FLAG=TRUE
+
+  nginx:
+    build:
+      context: ./prod/nginx
+      dockerfile: ./Dockerfile
+    restart: always
+    volumes:
+      - django-static:/app/static
+    ports:
+      - "8080:80"
+    depends_on:
+      - django
+
+  # nginx:
+  #   image: nginx:1.14.2
+  #   restart: always
+  #   ports:
+  #     - "80:80"
+  #   volumes:
+  #     - ./prod/stem-portal:/var/www/stem-portal
+  #     - ./prod/nginx:/etc/nginx/conf.d
+  #     - ./prod/logs:/var/logs/nginx
+  #   depends_on:
+  #     - django
+
+volumes:
+  postgres-config:
+  postgres-data:
+  postgres-logs:
+  django-static:

--- a/prod/nginx/Dockerfile
+++ b/prod/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:1.14.2
+
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d
+COPY stem-portal /var/www/stem-portal

--- a/prod/nginx/nginx.conf
+++ b/prod/nginx/nginx.conf
@@ -1,0 +1,35 @@
+upstream django {
+  server django:8000;
+}
+
+server {
+
+  listen 80;
+  server_name localhost;
+
+  location ^~ /api/ {
+    proxy_pass http://django;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+  }
+  
+  location ^~ /admin/ {
+    proxy_pass http://django;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $host;
+    proxy_redirect off;
+  }
+
+  location /static/ {
+    alias /app/static/;
+  }
+
+  location / {
+    root   /var/www/stem-portal;
+    index  index.html index.htm;
+  }
+
+  rewrite ^/home$ http://localhost:8080/ permanent;
+
+}

--- a/src/frontend/src/app/components/users/users.component.html
+++ b/src/frontend/src/app/components/users/users.component.html
@@ -1,9 +1,9 @@
 <div style="margin-top:20px;margin-bottom:20px;"><button (click)="getUsers()">Get Users</button></div>
 
-<div *ngFor="let result of results.data">
+<!-- <div *ngFor="let result of results.data"> -->
   <!-- {{queryResults | async | json}} -->
 
 
-  {{ result.attributes.last_name }}, {{ result.attributes.first_name }}
-</div>
+  <!-- {{ result.attributes.last_name }}, {{ result.attributes.first_name }} -->
+<!-- </div> -->
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -5,6 +5,7 @@ django-filter==2.1.0
 django-spa==0.2.0
 djangorestframework==3.9.1
 djangorestframework-jwt==1.11.0
+gunicorn==19.9.0
 Markdown==3.0.1
 psycopg2-binary==2.7.7
 PyJWT==1.7.1


### PR DESCRIPTION
This is the start to #168. This puts the files in place to be able to deploy to a production server.

**There's still some work to be done!** All API URLs are hardcoded to port 8000 which is only visible internally to docker-compose in production. Once we get these pulls out, we'll be able to easily flip the URLs so they dynamically point to the correct locations in dev and prod.