### PR TITLE
Move authentication back to the email field instead of username

### DIFF
--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -27,7 +27,7 @@ class User(AbstractUser):
     is_student = models.BooleanField(default=False)
     interests = models.ManyToManyField(Tag, related_name="users", blank=True)
 
-    USERNAME_FIELD = "username"
+    USERNAME_FIELD = "email"
     REQUIRED_FIELDS = []
 
     def __str__(self):

--- a/src/app/signals/signals.py
+++ b/src/app/signals/signals.py
@@ -35,7 +35,7 @@ def log_user_logged_in_failed(sender, credentials, request, **kwargs):
     try:
         user_agent_info = request.META.get('HTTP_USER_AGENT', '<unknown>')[:255],
         user_login_activity_log = UserLoginActivity(login_IP=get_client_ip(request),
-                                                    login_username=credentials['username'],
+                                                    login_username=credentials['email'],
                                                     user_agent_info=user_agent_info,
                                                     status=UserLoginActivity.FAILED)
         user_login_activity_log.save()

--- a/src/frontend/src/app/services/authentication.service.ts
+++ b/src/frontend/src/app/services/authentication.service.ts
@@ -35,7 +35,7 @@ export class AuthenticationService {
   }
 
   login(email: string, password: string) {
-    return this.http.post<any>(`${this.apiLoginUrl}`, { username: email, password })
+    return this.http.post<any>(`${this.apiLoginUrl}`, { email: email, password })
       .pipe(map(user => {
         // login successful if there's a jwt token in the response
         if (user && user.token) {


### PR DESCRIPTION
Let's move authentication back to `email` for now but still include account lockouts.