### PR TITLE
Move stem-portal to port 80

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -41,7 +41,7 @@ services:
     volumes:
       - django-static:/app/static
     ports:
-      - "8080:80"
+      - "80:80"
     depends_on:
       - django
 

--- a/prod/nginx/nginx.conf
+++ b/prod/nginx/nginx.conf
@@ -4,7 +4,7 @@ upstream django {
 
 server {
 
-  listen 8080;
+  listen 80;
   server_name localhost;
   port_in_redirect off;
   absolute_redirect off;


### PR DESCRIPTION
Now that we know we can stop all other services on the server, we can utilize port 80 to simply use `stem-ecosystem.mlhale.com` to get to the site in prod.