### PR TITLE
Limit event creation

### DIFF
--- a/src/app/controllers/event_controller.py
+++ b/src/app/controllers/event_controller.py
@@ -32,7 +32,6 @@ class EventViewSet(viewsets.ModelViewSet):
         return super(EventViewSet, self).get_permissions()
 
     def perform_create(self, serializer):
-        print(self.request.user)
         serializer.save(organizer=self.request.user)
 
     @action(detail=False, methods=['get'])

--- a/src/app/controllers/event_controller.py
+++ b/src/app/controllers/event_controller.py
@@ -1,11 +1,17 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import action
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated, BasePermission
 from datetime import date
 
 from app.models.event import Event
 from app.serializers.event_serializer import EventSerializer
+
+class EventCreation(BasePermission):
+    def has_permission(self, request, view):
+        if request.user.is_authenticated:
+            return request.user.get_approved_to_post_events()
+        return False
 
 class EventViewSet(viewsets.ModelViewSet):
     queryset = Event.objects.all()
@@ -21,6 +27,8 @@ class EventViewSet(viewsets.ModelViewSet):
     def get_permissions(self):
         if self.request.method == 'GET':
             self.permission_classes = [AllowAny,]
+        elif self.request.method == 'POST':
+            self.permission_classes = [EventCreation,]
         return super(EventViewSet, self).get_permissions()
 
     def perform_create(self, serializer):

--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -57,6 +57,12 @@ class User(AbstractUser):
     def role(self):
         return self.get_user_type_display().capitalize()
 
+    def get_approved_to_post_events(self):
+        if self.organization:
+            if self.organization.approved and self.approved_to_post_events:
+                return True
+        return False
+
     def unlock_account(self):
         if not self.account_locked:
             return None

--- a/src/app/serializers/user_serializer.py
+++ b/src/app/serializers/user_serializer.py
@@ -51,10 +51,7 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         return user
 
     def get_approved_to_post_events(self, user):
-        if user.organization:
-            if user.organization.approved and user.approved_to_post_events:
-                return True
-        return False
+        return user.get_approved_to_post_events()
 
     def validate_username(self, value):
         return bleach.clean(value)

--- a/src/frontend/src/app/components/events/event-routing.module.ts
+++ b/src/frontend/src/app/components/events/event-routing.module.ts
@@ -3,12 +3,13 @@ import { Routes, RouterModule } from '@angular/router';
 import { EventAddComponent } from './event-add/event-add.component';
 import { EventListComponent } from './event-list/event-list.component';
 import { EventSearchComponent} from './event-search/event-search.component';
+import { AuthGuard } from '../../services/guards/auth-guard.service';
 
 const eventRoutes: Routes = [
   { path: 'events', redirectTo: 'home', pathMatch: 'full' },
   { path: 'events',
     children: [
-      { path: 'add', component: EventAddComponent },
+      { path: 'add', component: EventAddComponent, canActivate: [AuthGuard] },
       { path: 'search', component: EventSearchComponent},
       { path: 'search/:term', component: EventSearchComponent}
     ]

--- a/src/frontend/src/app/services/guards/auth-guard.service.ts
+++ b/src/frontend/src/app/services/guards/auth-guard.service.ts
@@ -12,6 +12,16 @@ export class AuthGuard implements CanActivate {
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
         const currentUser = this.authenticationService.currentUserValue;
+        
+        // check if the user is trying to create an event
+        if (state.url === "/events/add") {
+            if (currentUser) {
+                if (this.authenticationService.approvedToPostEvents) { return true; };
+            }
+            this.router.navigate(['/home']);
+            return false;
+        }
+
         if (currentUser) {
             // logged in so return true
             return true;


### PR DESCRIPTION
This PR closes #198 by limiting access to event creation on the backend and frontend. Previously, we had the following issues:

### Frontend

User's may not have the `+` button but they could still navigate to `/events/add` to create new events.

The fix involves checking if the user is trying to create an event and redirecting to the `/home` page if they don't have access to create events based on the authentication service.

### Backend

Even if we limit the frontend routes, any authenticated user could create events through the API.

The fix was to add a permission check on the user object to see if they had rights to create events and approve/deny access accordingly. 