### PR TITLE
Add event tags on create

### DIFF
--- a/src/app/serializers/event_serializer.py
+++ b/src/app/serializers/event_serializer.py
@@ -1,12 +1,13 @@
 from app.models.user import User
 from app.models.event import Event
+from app.models.tag import Tag
 from rest_framework import serializers
 import bleach
 
 class EventSerializer(serializers.HyperlinkedModelSerializer):
     organizer = serializers.HyperlinkedRelatedField(view_name='user-detail', queryset=User.objects.all(), default=serializers.CurrentUserDefault())
     date = serializers.DateField(format="%m/%d/%Y", input_formats=['%m/%d/%Y', 'iso-8601'])
-    tags = serializers.StringRelatedField(many=True)
+    tags = serializers.SlugRelatedField(queryset=Tag.objects.all(), many=True, required=False, slug_field='name')
 
     class Meta:
         model = Event

--- a/src/frontend/src/app/components/events/event-add/event-add.component.html
+++ b/src/frontend/src/app/components/events/event-add/event-add.component.html
@@ -29,6 +29,12 @@
               <mat-option *ngFor="let type of event_types" [value]="type">{{type}}</mat-option>
             </mat-select>
           </mat-form-field>
+
+          <mat-form-field fxFlex="48" fxFlex.lt-sm="90">
+            <mat-select placeholder="Event Tags" formControlName="tags" multiple>
+              <mat-option *ngFor="let tag of tags" [value]="tag.name">{{ tag.name }}</mat-option>
+            </mat-select>
+          </mat-form-field>
         </div>
         <div style="text-align: center; margin-top:20px; margin-bottom:20px;">
           <button type="submit" mat-raised-button>Create Event</button>

--- a/src/frontend/src/app/components/events/event-add/event-add.component.ts
+++ b/src/frontend/src/app/components/events/event-add/event-add.component.ts
@@ -4,6 +4,8 @@ import { MatDialog } from '@angular/material';
 import { Router } from '@angular/router';
 import { EventService } from '../../../services/event-service.service';
 import { Event } from 'src/app/models/event';
+import { Tag } from '../../../models/tag';
+import { TagService } from '../../../services/tag.service';
 
 @Component({
   selector: 'app-event-add',
@@ -16,10 +18,12 @@ export class EventAddComponent implements OnInit {
   public errors: any = [];
   event_types = ['Community', 'Camp'];
   event: Event;
+  tags: Tag[];
 
   constructor(
     private fb: FormBuilder, public dialog: MatDialog,
-    private router: Router, private eventService: EventService
+    private router: Router, private eventService: EventService,
+    private tagService: TagService
   ) { }
 
   ngOnInit() {
@@ -29,15 +33,18 @@ export class EventAddComponent implements OnInit {
         name: ['', [Validators.required]],
         date: ['', [Validators.required]],
         e_type: ['', [Validators.required]],
+        tags: ['', ]
       })
     });
+    this.getTags();
   }
 
   onSubmit() {
     this.eventService.addEvent(
       this.eventForm.get('eventGroup').get('name').value,
       this.eventForm.get('eventGroup').get('date').value,
-      this.eventForm.get('eventGroup').get('e_type').value)
+      this.eventForm.get('eventGroup').get('e_type').value,
+      this.eventForm.get('eventGroup').get('tags').value)
       .subscribe(event => {
         this.event = event;
         this.router.navigate(['/home']);
@@ -48,6 +55,13 @@ export class EventAddComponent implements OnInit {
   getErrorMessage(groupName: string, controlName: string) {
     return this.eventForm.get(groupName).get(controlName).hasError('required') ? 'You must enter a value' :
       '';
+  }
+
+  getTags() {
+    this.tagService.getTags()
+      .subscribe(tags => {
+        this.tags = tags;
+      });
   }
 }
 

--- a/src/frontend/src/app/services/event-service.service.ts
+++ b/src/frontend/src/app/services/event-service.service.ts
@@ -27,12 +27,12 @@ export class EventService {
     return this.http.get<Event[]>(`/api/v1/events/search/${searchTerm}`);
   }
 
-  addEvent(eventName: string, eventDate: Date, eventType: string): Observable<Event> {
+  addEvent(eventName: string, eventDate: Date, eventType: string, eventTags: string[]): Observable<Event> {
     const obj = {
       name: eventName,
       date: eventDate.toLocaleDateString('en-US'),
       event_type: eventType,
-      tags: []
+      tags: eventTags
     };
 
     var user = JSON.parse(localStorage.currentUser);


### PR DESCRIPTION
One major thing missing is allowing users to attach event tags when they create events. This adds that feature to the frontend and backend of the app!

![Screen Recording 2019-04-27 at 11 40 AM](https://user-images.githubusercontent.com/35509748/56852471-7c121180-68e1-11e9-8bae-5d8e1988b6b5.gif)
