### PR TITLE
Show events even if they're missing tags

### DIFF
--- a/src/frontend/src/app/components/home/home.component.html
+++ b/src/frontend/src/app/components/home/home.component.html
@@ -19,4 +19,25 @@
     </swiper>
     <mat-divider></mat-divider>
   </div>
+
+  <div *ngFor="let event of otherEvents">
+    <div>
+      <h3>Other Events</h3><br>
+    </div>
+
+    <swiper [config]="config">
+      <div class="swiper-wrapper">
+          <div class="swiper-slide">
+              <app-event-list [name]="event.name" [date]="event.date" [event_type]="event.event_type" [event_address]="event.address" [tags]="event.tags">
+              </app-event-list>
+            </div>
+      </div>
+      <!-- Add Pagination -->
+      <div class="swiper-pagination"></div>
+      <!-- Add Arrows -->
+      <div class="swiper-button-next"></div>
+      <div class="swiper-button-prev"></div>
+    </swiper>
+    <mat-divider></mat-divider>
+  </div>
 </div>

--- a/src/frontend/src/app/components/home/home.component.ts
+++ b/src/frontend/src/app/components/home/home.component.ts
@@ -17,6 +17,7 @@ export class HomeComponent implements OnInit {
   events: Event[];
   categories: Tag[];
   tevents: Event[];
+  otherEvents: Event[];
   error: string;
   imageSource: string;
   mySlideOptions = { dots: false, nav: true};
@@ -35,6 +36,7 @@ export class HomeComponent implements OnInit {
   constructor(private userService: UserService, private eventService: EventService,
               private authenticationService: AuthenticationService) {
                 this.categories = [];
+                this.otherEvents = [];
               }
 
   ngOnInit() {
@@ -72,9 +74,15 @@ export class HomeComponent implements OnInit {
       .subscribe(events => {
         this.events = events;
         this.events.forEach(event => {
-          event.tags.forEach(tag => {
-            if (!this.categories.includes(tag)) { this.categories.push(tag); }
-          });
+          // check if the event has tags
+          if (event.tags.length > 0) {
+            event.tags.forEach(tag => {
+              if (!this.categories.includes(tag)) { this.categories.push(tag); }
+            });
+          } else {
+            // add the event to a list of "other" events if there are no tags
+            this.otherEvents.push(event);
+          }
         });
       });
   }


### PR DESCRIPTION
Previously, events would be completely missing from the app if there were no tags associated. This PR shows them at the bottom after every other category to encourage tag usage.

![Screen Recording 2019-04-27 at 12 02 PM](https://user-images.githubusercontent.com/35509748/56852741-7964eb80-68e4-11e9-9b1a-8128754d5948.gif)
