### PR TITLE
Make username a required field for `createsuperuser`

### DIFF
--- a/src/app/models/user.py
+++ b/src/app/models/user.py
@@ -32,7 +32,7 @@ class User(AbstractUser):
     interests = models.ManyToManyField(Tag, related_name="users", blank=True)
 
     USERNAME_FIELD = "email"
-    REQUIRED_FIELDS = []
+    REQUIRED_FIELDS = ["username"]
 
     def __str__(self):
         user_string = ""


### PR DESCRIPTION
One issue I found was running `createsuperuser` doesn't ask for a `username` and thus bombs out on creation. This adds that field to the create form so we can create super users through the console!